### PR TITLE
fix(clustername): remove multiple spaces from git user name

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -2,7 +2,7 @@
 set -eox pipefail
 
 [ -z ${CDK_EMQX_CLUSTERNAME+x} ] &&
-    CDK_EMQX_CLUSTERNAME=$(git config --get user.name | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]//')
+    CDK_EMQX_CLUSTERNAME=$(git config --get user.name | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]//g')
 
 docker run -e CDK_EMQX_CLUSTERNAME=${CDK_EMQX_CLUSTERNAME} --rm -it \
        -v ~/.aws:/root/.aws -v $(pwd):/opt/ contino/aws-cdk \


### PR DESCRIPTION
This takes into account multiple spaces in the user's username:

```sh
echo a b c d | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]//'
ab c d

echo a b c d | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]//g'
abcd
```