### PR TITLE
feat(rlog): add facilities to spin up a cluster using rlog

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -21,6 +21,15 @@ emqx_ins_type
 # default: 2
 emqx_n
 
+# Type of DB Backend
+# choice: "mnesia" | "rlog"
+# default: "mnesia"
+emqx_db_backend
+
+# Number of core nodes. Only relevant if `emqx_db_backend' = "rlog"
+# default: same as `emqx_n'
+emqx_num_core_nodes
+
 # Loadgen instance type
 # default: # default: t3a.small
 loadgen_ins_type
@@ -33,8 +42,8 @@ lg_n
 # default: null
 emqx_ebs
 
-# Specify how to fetch emqx package 
-# either by downloading deb 
+# Specify how to fetch emqx package
+# either by downloading deb
 # emqx_src="wget https://www.emqx.io/downloads/broker/v4.3.0/emqx-ubuntu20.04-4.3.0-amd64.deb"
 # OR
 # build from src
@@ -81,7 +90,7 @@ CDK_EMQX_CLUSTERNAME=william cdk synth
 
 ## Real run
 ```bash
-CDK_EMQX_CLUSTERNAME=william cdk deploy 
+CDK_EMQX_CLUSTERNAME=william cdk deploy
 ```
 
 ## Lazy Note: If you want to deploy EMQX with private branch, with 5 emqx nodes

--- a/bin/container-entrypoint.sh
+++ b/bin/container-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash --init-file
 npm install -g aws-cdk
 python3 -m venv .venv
-cd /opt/
 source .venv/bin/activate
+cd /opt/
 pip3 install -r requirements.txt

--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -61,7 +61,14 @@ config_overrides_v5() {
   nodename="emqx@`hostname -f`"
   cat <<EOF >> /etc/emqx/emqx.conf
 node {
- name: $nodename
+  name: $nodename
+
+  ## Erlang Process Limit
+  process_limit: 2097152
+
+  ## Sets the maximum number of simultaneously existing ports for this
+  ## system
+  max_ports: 1048576
 }
 
 cluster {
@@ -74,7 +81,8 @@ cluster {
 }
 
 listeners.tcp.default {
- acceptors: 128
+  acceptors: 128
+  max_connections: 1024000
 }
 
 rate_limit {
@@ -90,11 +98,10 @@ prometheus {
 }
 
 gateway.exproto {
-server {
-  bind = 9101
- }
+  server {
+    bind = 9101
+  }
 }
-
 
 rate_limit {
   ## Maximum connections per second.


### PR DESCRIPTION
This adds a few parameters to help spinning up an EMQX cluster using
the RLOG DB Backend with different number of core/replicant nodes.