### PR TITLE
fix(config): remove unknown config keys

### DIFF
--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -62,13 +62,6 @@ config_overrides_v5() {
   cat <<EOF >> /etc/emqx/emqx.conf
 node {
   name: $nodename
-
-  ## Erlang Process Limit
-  process_limit: 2097152
-
-  ## Sets the maximum number of simultaneously existing ports for this
-  ## system
-  max_ports: 1048576
 }
 
 cluster {


### PR DESCRIPTION
It seems that the 4.3 documentation has no equivalent for
`node.{process_limit,max_ports}` in 5.0.

https://docs.emqx.io/en/broker/v4.3/tutorial/tune.html#erlang-vm-tuning