### PR TITLE
fix: rm unknown argument to `efs.FileSystem`

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -888,6 +888,4 @@ class CdkEmqxClusterStack(cdk.Stack):
                                              lifecycle_policy=efs.LifecyclePolicy.AFTER_14_DAYS,
                                              performance_mode=efs.PerformanceMode.GENERAL_PURPOSE,
                                              security_group=self.sg_efs_mt,
-                                             file_system_tags=[efs.CfnFileSystem.ElasticFileSystemTagProperty(
-                                                 key="cluster", value=self.cluster_name)]
                                              )


### PR DESCRIPTION
It seems that `file_system_tags` is a property of `efs.CfnFileSystem`
only:

```
Traceback (most recent call last):
  File "/opt/app.py", line 22, in <module>
    CdkEmqxClusterStack(app, "CdkEmqxClusterStack", stack_name = stack_name
  File "/venv/lib/python3.9/site-packages/jsii/_runtime.py", line 86, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/opt/cdk_emqx_cluster/cdk_emqx_cluster_stack.py", line 160, in __init__
    self.setup_efs()
  File "/opt/cdk_emqx_cluster/cdk_emqx_cluster_stack.py", line 881, in setup_efs
    self.shared_efs = efs.FileSystem(self, id=fsid, vpc=self.vpc,
  File "/venv/lib/python3.9/site-packages/jsii/_runtime.py", line 86, in __call__
    inst = super().__call__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'file_system_tags'
```