### PR TITLE
feat(rlog): allow to specify instance type for core nodes

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -17,6 +17,11 @@ All configs are optional, specify with `cdk deploy -c k1=v1 -c k2=v2`
 emqx_ins_type
 
 
+# EMQX instance type for Core nodes (RLOG DB backend)
+# default: same as emqx_ins_type
+emqx_core_ins_type
+
+
 # Number of EMQXs
 # default: 2
 emqx_n
@@ -220,7 +225,7 @@ CDK_EMQX_CLUSTERNAME=william cdk destroy CdkEmqxClusterStack
 
 For some more relevant performance tests, you can use larger instances. For a two node emqx cluster with one loadgen with a particular branch:
 ```bash
-CDK_EMQX_CLUSTERNAME=william cdk deploy --all -c emqx_src="git clone -b YOUR_BRANCH https://github.com/emqx/emqx" -c emqx_n=2 -c emqx_ins_type="m5.2xlarge" -c loadgen_ins_type="m5n.xlarge" -c emqx_ebs=20 
+CDK_EMQX_CLUSTERNAME=william cdk deploy --all -c emqx_src="git clone -b YOUR_BRANCH https://github.com/emqx/emqx" -c emqx_n=2 -c emqx_ins_type="m5.2xlarge" -c loadgen_ins_type="m5n.xlarge" -c emqx_ebs=20
 ```
 The `emqx_ebs` is needed since these instances do not have storage by default.
 

--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -560,15 +560,19 @@ class CdkEmqxClusterStack(cdk.Stack):
             multipartUserData.add_part(
                 ec2.MultipartBody.from_user_data(user_data_nginx))
 
+            if isCore:
+                ins_type = self.emqx_core_ins_type
+            else:
+                ins_type = self.emqx_ins_type
 
-            if (self.emqx_ins_type[2] == 'g'): #Graviton2
+            if (ins_type[2] == 'g'): #Graviton2
                 ami = ubuntu_arm_ami
             else:
                 ami = ubuntu_x86_64_ami
 
             vm = ec2.Instance(self, id=name,
                               instance_type=ec2.InstanceType(
-                                  instance_type_identifier=self.emqx_ins_type),
+                                  instance_type_identifier=ins_type),
                               block_devices=blockdevs,
                               machine_image=ami,
                               user_data=multipartUserData,
@@ -822,6 +826,11 @@ class CdkEmqxClusterStack(cdk.Stack):
         # suggested m5.2xlarge
         self.emqx_ins_type = self.node.try_get_context(
             'emqx_ins_type') or 't3a.small'
+
+        # Instance size for core nodes (when using RLOG DB backend)
+        # defaults to `emqx_ins_type' if unspecified
+        self.emqx_core_ins_type = self.node.try_get_context(
+            'emqx_core_ins_type') or self.emqx_ins_type
 
         # Number of EMQXs
         self.numEmqx = int(self.node.try_get_context('emqx_n') or 2)


### PR DESCRIPTION
To enable the usage of (potentially) larger instances for core nodes
when using the RLOG DB backend, we add a new `emqx_core_ins_type`
parameter that can be specified.  It defaults to the same as
`emqx_ins_type`.