### PR TITLE
feat: allow specifying postgres password

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -73,6 +73,13 @@ retain_efs
 # default: ghcr.io/emqx/emqx-builder/5.0-4:1.13.1-24.1.5-3-ubuntu20.04
 emqx_builder_image
 
+# Monitoring Postgres password
+# Set the password for the Postgres instance that is used by system_monitor
+# If unset, a random one will be generated.
+# If using a retained EFS, you should take note of the generated password
+# because it'll be persisted between clusters.
+emqx_monitoring_postgres_password
+
 ```
 
 ## Make sure you have AWS credentials in ~/.aws/

--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -195,6 +195,7 @@ class CdkEmqxClusterStack(cdk.Stack):
                        % (self.bastion.instance_public_ip, self.mon_lb, self.mon_lb, self.mon_lb)
                        )
         core.CfnOutput(self, 'EFS ID:', value=self.shared_efs.file_system_id)
+        core.CfnOutput(self, 'Monitoring Postgres Password:', value=self.postgresPass)
 
         if self.kafka_ebs_vol_size:
             core.CfnOutput(self, 'KAFKA Brokers:', value=self.kafka.bootstrap_brokers)
@@ -877,7 +878,8 @@ class CdkEmqxClusterStack(cdk.Stack):
             raise RuntimeError(f"invalid `emqx_db_backend': {dbBackend}")
         self.dbBackend = dbBackend
         # Not cryptographically safe, but better than nothing
-        self.postgresPass = get_random_string()
+        self.postgresPass = self.node.try_get_context(
+            'emqx_monitoring_postgres_password') or get_random_string()
 
         # Number of core nodes. Only relevant if `emqx_db_backend' = "rlog"
         # default: same as `emqx_n'


### PR DESCRIPTION
If using a retained EFS, one should take note of the generated
password because it'll be persisted between clusters.