### PR TITLE
feat: allow bastion to use s3 bucket

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -780,6 +780,8 @@ class CdkEmqxClusterStack(cdk.Stack):
                                        security_group=sg_bastion,
                                        instance_name="BastionHostLinux %s" % self.cluster_name,
                                        instance_type=ec2.InstanceType(instance_type_identifier="t3.nano"))
+        # allow uploading TSDB snapshots to S3
+        self.attach_s3_policy(bastion.role)
 
         bastion.instance.instance.add_property_override(
             "KeyName", self.ssh_key)


### PR DESCRIPTION
To allow us to upload Prometheus TSDB snapshots to S3, we attach the
same S3 policy that the EMQ X nodes already have to the bastion
instance as well, since the snapshots reside there.