### PR TITLE
chore(system_monitor): Bump image versions

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -430,7 +430,7 @@ class CdkEmqxClusterStack(cdk.Stack):
         c_postgres = task.add_container('postgres',
                                         essential=True,
                                         image=ecs.ContainerImage.from_registry(
-                                            'ghcr.io/k32/sysmon-postgres:0.1.2'),
+                                            'ghcr.io/k32/sysmon-postgres:1.0.0'),
                                         port_mappings=[
                                             ecs.PortMapping(container_port=5432)],
                                         # It looks like postgres doesn't want to die sometimes
@@ -469,9 +469,10 @@ class CdkEmqxClusterStack(cdk.Stack):
         c_grafana = task.add_container('grafana',
                                        essential=True,
                                        image=ecs.ContainerImage.from_registry(
-                                           'ghcr.io/k32/sysmon-grafana:0.1.2'),
+                                           'ghcr.io/k32/sysmon-grafana:1.0.0'),
                                        environment={
-                                           'POSTGRES_PASS': self.postgresPass
+                                           'POSTGRES_PASS': self.postgresPass,
+                                           'GF_AUTH_ANONYMOUS_ENABLED': true
                                        },
                                        port_mappings=[
                                            ecs.PortMapping(container_port=3000)]


### PR DESCRIPTION
The volume should be recreated from schratch, since the schema is incompatible.