### PR TITLE
fix: string environment variable

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -472,7 +472,7 @@ class CdkEmqxClusterStack(cdk.Stack):
                                            'ghcr.io/k32/sysmon-grafana:1.0.0'),
                                        environment={
                                            'POSTGRES_PASS': self.postgresPass,
-                                           'GF_AUTH_ANONYMOUS_ENABLED': true
+                                           'GF_AUTH_ANONYMOUS_ENABLED': "true"
                                        },
                                        port_mappings=[
                                            ecs.PortMapping(container_port=3000)]


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/app.py", line 22, in <module>
    CdkEmqxClusterStack(app, "CdkEmqxClusterStack", stack_name = stack_name
  File "/venv/lib/python3.9/site-packages/jsii/_runtime.py", line 86, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/opt/cdk_emqx_cluster/cdk_emqx_cluster_stack.py", line 170, in __init__
    self.setup_monitoring(self.hosts)
  File "/opt/cdk_emqx_cluster/cdk_emqx_cluster_stack.py", line 507, in setup_monitoring
    'GF_AUTH_ANONYMOUS_ENABLED': true
NameError: name 'true' is not defined
Subprocess exited with error 1
```