### PR TITLE
fix container image references

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -434,7 +434,7 @@ class CdkEmqxClusterStack(cdk.Stack):
         c_postgres = task.add_container('postgres',
                                         essential=True,
                                         image=ecs.ContainerImage.from_registry(
-                                            'ghcr.io/ieQu1/sysmon-postgres:1.3.1'),
+                                            'ghcr.io/iequ1/sysmon-postgres:1.3.1'),
                                         port_mappings=[
                                             ecs.PortMapping(container_port=5432)],
                                         # It looks like postgres doesn't want to die sometimes
@@ -473,7 +473,7 @@ class CdkEmqxClusterStack(cdk.Stack):
         c_grafana = task.add_container('grafana',
                                        essential=True,
                                        image=ecs.ContainerImage.from_registry(
-                                           'ghcr.io/ieQu1/sysmon-grafana:1.3.1'),
+                                           'ghcr.io/iequ1/sysmon-grafana:1.3.1'),
                                        environment={
                                            'POSTGRES_PASS': self.postgresPass,
                                            'GF_AUTH_ANONYMOUS_ENABLED': "true"


### PR DESCRIPTION
Apparently, docker registry image references are required to contain
only lowercase letters.