### PR TITLE
chore(emqx): disable docker after installation

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -53,12 +53,15 @@ emqx_ebs
 # default: null, (no kafka)
 kafka_ebs
 
-# Specify how to fetch emqx package
-# either by downloading deb
-# emqx_src="wget https://www.emqx.io/downloads/broker/v4.3.0/emqx-ubuntu20.04-4.3.0-amd64.deb"
-# OR
-# build from src
-# emqx_src="git clone -b some_branch https://github.com/emqx/emqx"
+# Specify how to fetch emqx package by 
+# 
+# - Download deb file from web
+#   emqx_src="wget https://www.emqx.io/downloads/broker/v4.3.0/emqx-ubuntu20.04-4.3.0-amd64.deb"
+# - Fetch deb file from S3. Note, emqx node only has access to cluster bucket: s3://emqx-cdk-cluster/${cluster_name}
+#   emqx_src="aws s3 cp s3://emqx-cdk-cluster/william-k2/emqx-5.0.0-beta.3-7f31cd08-otp24.2.1-ubuntu20.04-amd64.deb ./"
+# - build from src
+#   emqx_src="git clone -b some_branch https://github.com/emqx/emqx"
+#
 # default: "git clone https://github.com/emqx/emqx"
 emqx_src
 

--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -916,7 +916,7 @@ class CdkEmqxClusterStack(cdk.Stack):
         # LOADGEN Instance Type
         # suggested m5n.xlarge
         self.loadgen_ins_type = self.node.try_get_context(
-            'loadgen_ins_type') or 't3a.micro'
+            'loadgen_ins_type') or 't3a.small'
 
         # Number of LOADGENS
         self.numLg = int(self.node.try_get_context('lg_n') or 1)

--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -73,7 +73,7 @@ maybe_install_from_src() {
            -e EMQX_NAME="emqx" \
            -e HOME="/root" \
            "$EMQX_BUILDER_IMAGE" \
-           bash -c "make && make $EMQX_BUILD_PROFILE"
+           bash -c "make $EMQX_BUILD_PROFILE"
     dpkg -i ./_packages/emqx/*.deb
     disable_docker
   fi

--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -18,25 +18,32 @@ EOF
 
 sysctl -p
 
-# we need docker to pull and use emqx-builder
-apt update
-apt install -y \
+install_docker() {
+  # we need docker to pull and use emqx-builder
+  apt update
+  apt install -y \
     ca-certificates \
     curl \
     gnupg \
     lsb-release
 
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-  gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-apt update
-apt install -y docker-ce docker-ce-cli containerd.io
+  apt update
+  apt install -y docker-ce docker-ce-cli containerd.io
 
-docker pull "$EMQX_BUILDER_IMAGE"
+  docker pull "$EMQX_BUILDER_IMAGE"
+}
+
+disable_docker() {
+  systemctl stop docker
+  systemctl disable docker
+}
 
 maybe_mount_data() {
   if [ -b /dev/nvme1n1 ]; then
@@ -58,6 +65,7 @@ maybe_install_from_src() {
   pushd ./
   if [ -d emqx ]; then
     echo "Find emqx source code, install from source code..."
+    install_docker
     cd emqx
     docker run --rm -i \
            -v "$PWD":/emqx \
@@ -65,8 +73,9 @@ maybe_install_from_src() {
            -e EMQX_NAME="emqx" \
            -e HOME="/root" \
            "$EMQX_BUILDER_IMAGE" \
-           bash -c "make $EMQX_BUILD_PROFILE"
+           bash -c "make && make $EMQX_BUILD_PROFILE"
     dpkg -i ./_packages/emqx/*.deb
+    disable_docker
   fi
   popd
 }

--- a/user_data/loadgen_init.sh
+++ b/user_data/loadgen_init.sh
@@ -11,8 +11,6 @@ EOF
 
 sysctl -p
 
-domain=$(dnsdomainname)
-
 cd /root/
 git clone -b "master" https://github.com/emqx/emqtt-bench.git
 cd emqtt-bench


### PR DESCRIPTION
Docker enables nf_conntrack that is undesired kernel module.

We only use docker for build emqx package on emqx node, so we have two following
changes:

a. Don't install docker for deb package installation
b. Disable docker after built from emqx src
   You need to restart VM to disable nf_conntrack afterwards.

Change the default loadgen instance type to t3a.small

note, we don't use docker on loadgen VMs.