### PR TITLE
fix: increase prometheus retention time to 1 year

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -409,6 +409,7 @@ class CdkEmqxClusterStack(cdk.Stack):
                                               "--storage.tsdb.path=/prometheus/tsdb_data",
                                               "--web.console.libraries=/usr/share/prometheus/console_libraries",
                                               "--web.console.templates=/usr/share/prometheus/consoles",
+                                              "--storage.tsdb.retention.time=1y",
                                               "--web.enable-admin-api"
                                           ],
                                           # uncomment for troubleshooting


### PR DESCRIPTION
The default retention time for prometheus is only 15 days.  So, data
before 15 days is deleted if this limit is not increased.