### PR TITLE
chore: redirect ssh tunnel errors to /dev/null

### DIFF
--- a/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
+++ b/cdk_emqx_cluster/cdk_emqx_cluster_stack.py
@@ -190,6 +190,7 @@ class CdkEmqxClusterStack(cdk.Stack):
                              f"-L 13000:{self.mon_lb}:3000 "
                              f"-L 19090:{self.mon_lb}:9090 "
                              f"-L 15432:{self.mon_lb}:5432 "
+                             "2>/dev/null"
                        )
         core.CfnOutput(self, 'EFS ID:', value=self.shared_efs.file_system_id)
         core.CfnOutput(self, 'Monitoring Postgres Password:', value=self.postgresPass)


### PR DESCRIPTION
Frequently, when one uses the SSH tunnel, has the EMQX dashboard
open in the browser and restarts the nodes, the terminal with the
SSH tunnel is flooded with messages from the dashboard trying to fetch
updates from the nodes, like this:

```
channel 17: open failed: connect failed: Connection refused
```