### PR TITLE
fix: copy code after installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ RUN python3 -m venv /venv
 COPY requirements.txt /setup/requirements.txt
 COPY setup.py /setup/setup.py
 COPY README.md /setup/
-COPY cdk_emqx_cluster /setup/cdk_emqx_cluster
+RUN mkdir -p /setup/cdk_emqx_cluster
 RUN cd /setup/ \
     && source /venv/bin/activate \
     && pip3 install --upgrade pip \
     && pip3 install -r requirements.txt
+COPY cdk_emqx_cluster /setup/cdk_emqx_cluster
 COPY bin/container-entrypoint.sh /container-entrypoint.sh
 ENTRYPOINT ["/container-entrypoint.sh"]


### PR DESCRIPTION
When we change the code, docker thinks that everything is invalidated,
so it builds the whole image again without using the cache.