### PR TITLE
fix: pin `jsii` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setuptools.setup(
         "aws-cdk.aws-stepfunctions==1.134.0",
         "aws-cdk.aws-stepfunctions-tasks==1.134.0",
         "pyyaml",
+        # jsii 1.65.0 is broken with out current cdk version
+        "jsii==1.61.0",
+        "attrs==21.4.0",
     ],
 
     python_requires=">=3.6",


### PR DESCRIPTION
Otherwise:

```
jsii.errors.JavaScriptError:
  @jsii/kernel.SerializationError: Passed to parameter props of new @aws-cdk/aws-iam.Role: Unable to deserialize value as @aws-cdk/aws-iam.RoleProps
  ├── 🛑 Failing value is an object
  │      { '$jsii.struct': [Object] }
  ╰── 🔍 Failure reason(s):
      ╰─ Key 'inlinePolicies': Unable to deserialize value as map<@aws-cdk/aws-iam.PolicyDocument> | undefined
          ├── 🛑 Failing value is an array
          │      [ [Object], [Object] ]
          ╰── 🔍 Failure reason(s):
              ╰─ Value is an array
      at Object.process (/tmp/tmp6mpk4lxp/lib/program.js:5753:19)
      at exports.Kernel._toSandbox (/tmp/tmp6mpk4lxp/lib/program.js:5418:29)
      at /tmp/tmp6mpk4lxp/lib/program.js:5443:42
      at Array.map (<anonymous>)
      at exports.Kernel._boxUnboxParameters (/tmp/tmp6mpk4lxp/lib/program.js:5443:27)
      at exports.Kernel._toSandboxValues (/tmp/tmp6mpk4lxp/lib/program.js:5434:29)
      at exports.Kernel._create (/tmp/tmp6mpk4lxp/lib/program.js:5182:42)
      at exports.Kernel.create (/tmp/tmp6mpk4lxp/lib/program.js:4989:29)
      at exports.KernelHost.processRequest (/tmp/tmp6mpk4lxp/lib/program.js:6083:36)
      at exports.KernelHost.run (/tmp/tmp6mpk4lxp/lib/program.js:6057:48)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/app.py", line 46, in <module>
    CdkChaosTest(app, "CDKChaosTest", stack_name = stack_name + 'chaostest'
  File "/venv/lib/python3.9/site-packages/jsii/_runtime.py", line 86, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/opt/cdk_emqx_cluster/cdk_chaos_test.py", line 42, in __init__
    role = IamRoleFis(self, id='emqx-fis-role')
  File "/venv/lib/python3.9/site-packages/jsii/_runtime.py", line 86, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/opt/cdk_emqx_cluster/cdk_chaos_test.py", line 289, in __init__
    super().__init__(scope,
  File "/venv/lib/python3.9/site-packages/aws_cdk/aws_iam/__init__.py", line 9543, in __init__
    jsii.create(self.__class__, self, [scope, id, props])
  File "/venv/lib/python3.9/site-packages/jsii/_kernel/__init__.py", line 321, in create
    response = self.provider.create(
  File "/venv/lib/python3.9/site-packages/jsii/_kernel/providers/process.py", line 347, in create
    return self._process.send(request, CreateResponse)
  File "/venv/lib/python3.9/site-packages/jsii/_kernel/providers/process.py", line 329, in send
    raise JSIIError(resp.error) from JavaScriptError(resp.stack)
jsii.errors.JSIIError: Passed to parameter props of new @aws-cdk/aws-iam.Role: Unable to deserialize value as @aws-cdk/aws-iam.RoleProps
├── 🛑 Failing value is an object
│      { '$jsii.struct': [Object] }
╰── 🔍 Failure reason(s):
    ╰─ Key 'inlinePolicies': Unable to deserialize value as map<@aws-cdk/aws-iam.PolicyDocument> | undefined
        ├── 🛑 Failing value is an array
        │      [ [Object], [Object] ]
        ╰── 🔍 Failure reason(s):
            ╰─ Value is an array
Subprocess exited with error 1
```