### PR TITLE
Provisioning fixes and improvements

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -43,6 +43,16 @@ loadgen_ins_type
 # default: 1
 lg_n
 
+# External resource instance TYPE
+# Nodes for external resources are just created and not used by the cluster.
+# They may be used to provision external resources like Redis, Postgres, etc.
+# default: t3a.small
+ext_ins_type
+
+# Number of nodes for external resources.
+# default: 0
+ext_n
+
 # Extra EBS vol size (in GB) for EMQX DATA per EMQX Instance
 # default: null
 emqx_ebs

--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -74,7 +74,7 @@ maybe_install_from_src() {
            -e HOME="/root" \
            "$EMQX_BUILDER_IMAGE" \
            bash -c "make $EMQX_BUILD_PROFILE"
-    dpkg -i ./_packages/emqx/*.deb
+    dpkg -i ./_packages/emqx*/*.deb
     disable_docker
   fi
   popd
@@ -251,7 +251,7 @@ maybe_mount_data
 maybe_install_from_deb
 maybe_install_from_src
 
-EMQX_VERSION=$(dpkg -s emqx emqx-ee | grep Version | awk '{print $2}')
+EMQX_VERSION=$(dpkg -s emqx emqx-ee emqx-enterprise | grep Version | awk '{print $2}')
 
 case "${EMQX_VERSION}" in
   4*)

--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -117,6 +117,12 @@ EOF
   esac
 }
 
+api_keys() {
+  cat <<EOF >> /etc/emqx/api_keys.conf
+key:secret
+EOF
+}
+
 config_overrides_v5() {
   domain=$(dnsdomainname)
   nodename="emqx@`hostname -f`"
@@ -202,6 +208,10 @@ node {
   process_limit = 134217727
 }
 
+api_key {
+  bootstrap_file = "/etc/emqx/api_keys.conf"
+}
+
 EOF
 }
 
@@ -258,6 +268,7 @@ case "${EMQX_VERSION}" in
     config_overrides_v4
     ;;
   5*)
+    api_keys
     config_overrides_v5
     maybe_config_overrides_v5
     ;;


### PR DESCRIPTION
* Set simple bootstrap API keys for v5 EE, simplifying API usage
* Fix v5 EE setup process
* Added `ext` type of nodes. Several times, I needed them to set up external resources (e.g., HStreamDB, now Redis). @qzhuyan @thalesmg I am not sure about the code style: seems that some duplication appears. But making the code DRY will likely make the setup process less readable.