### PR TITLE
fix: change default maximum number of ports and processes

### DIFF
--- a/user_data/emqx_init.sh
+++ b/user_data/emqx_init.sh
@@ -208,8 +208,10 @@ sysmon.top {
 }
 
 node {
-  max_ports = 134217727
-  process_limit = 134217727
+  # must be at most half the maximum number of processes...
+  max_ports = 67108863
+  # this is currently ignored...
+  # process_limit = 134217727
 }
 
 api_key {


### PR DESCRIPTION
After a [recent change](https://github.com/emqx/emqx/pull/11269), the process limit is no longer overridable, and the current value of max ports in CDK leads to an inconsistent max procs.