### PR TITLE
fix(otp): update system otp -> 25.3

### DIFF
--- a/user_data/os_common.sh
+++ b/user_data/os_common.sh
@@ -22,7 +22,7 @@ apt install -y make wget gnupg2 git build-essential curl cmake debhelper tmux li
 wget -O - https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | sudo apt-key add -
 echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | tee /etc/apt/sources.list.d/els.list
 apt update
-apt install -y esl-erlang=1:24.2.1-1
+apt install -y esl-erlang=1:25.3-1
 
 ## Install node exporter
 case $(uname -m) in


### PR DESCRIPTION
It seems we can no longer run `rebar3` `3.19.0-emqx-5` with OTP 24 when building `emqtt-bench`.

```
./rebar3 compile
escript: exception error: undefined function rebar3:main/1
  in function  escript:run/2 (escript.erl, line 750)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 
  in call from init:do_boot/3 
make: *** [Makefile:12: compile] Error 127
```